### PR TITLE
Fix sig skipping bug

### DIFF
--- a/contracts/ChannelManager.sol
+++ b/contracts/ChannelManager.sol
@@ -210,7 +210,7 @@ contract ChannelManager {
             timeout,
             "", // skip hub sig verification
             sigUser,
-            [false, true] // [checkHub, checkUser] <- only need to check user
+            [false, true] // [checkHubSig?, checkUser] <- only need to check user
         );
 
         _updateChannelBalances(channel, weiBalances, tokenBalances, pendingWeiUpdates, pendingTokenUpdates);
@@ -276,7 +276,7 @@ contract ChannelManager {
             timeout,
             sigHub,
             "", // skip user sig verification
-            [true, false] // [checkHub, checkUser] <- only need to check hub
+            [true, false] // [checkHubSig?, checkUser] <- only need to check hub
         );
 
         // transfer user token deposit to this contract
@@ -367,7 +367,7 @@ contract ChannelManager {
             timeout,
             sigHub,
             sigUser,
-            [true, true] // [checkHub, checkUser] <- check both sigs
+            [true, true] // [checkHubSig?, checkUser] <- check both sigs
         );
 
         require(txCount[0] > channel.txCount[0], "global txCount must be higher than the current global txCount");
@@ -442,7 +442,7 @@ contract ChannelManager {
             timeout,
             sigHub,
             sigUser,
-            [true, true] // [checkHub, checkUser] <- check both sigs
+            [true, true] // [checkHubSig?, checkUser] <- check both sigs
         );
 
         require(txCount[0] > channel.txCount[0], "global txCount must be higher than the current global txCount");
@@ -996,7 +996,7 @@ contract ChannelManager {
         uint256 timeout,
         string sigHub,
         string sigUser,
-        bool[2] checks
+        bool[2] checks // [checkHubSig?, checkUserSig?]
     ) internal view {
         require(user[0] != hub, "user can not be hub");
 

--- a/contracts/ChannelManager.sol
+++ b/contracts/ChannelManager.sol
@@ -209,7 +209,8 @@ contract ChannelManager {
             threadCount,
             timeout,
             "", // skip hub sig verification
-            sigUser
+            sigUser,
+            [false, true] // [checkHub, checkUser] <- only need to check user
         );
 
         _updateChannelBalances(channel, weiBalances, tokenBalances, pendingWeiUpdates, pendingTokenUpdates);
@@ -274,7 +275,8 @@ contract ChannelManager {
             threadCount,
             timeout,
             sigHub,
-            "" // skip user sig verification
+            "", // skip user sig verification
+            [true, false] // [checkHub, checkUser] <- only need to check hub
         );
 
         // transfer user token deposit to this contract
@@ -364,7 +366,8 @@ contract ChannelManager {
             threadCount,
             timeout,
             sigHub,
-            sigUser
+            sigUser,
+            [true, true] // [checkHub, checkUser] <- check both sigs
         );
 
         require(txCount[0] > channel.txCount[0], "global txCount must be higher than the current global txCount");
@@ -438,7 +441,8 @@ contract ChannelManager {
             threadCount,
             timeout,
             sigHub,
-            sigUser
+            sigUser,
+            [true, true] // [checkHub, checkUser] <- check both sigs
         );
 
         require(txCount[0] > channel.txCount[0], "global txCount must be higher than the current global txCount");
@@ -991,7 +995,8 @@ contract ChannelManager {
         uint256 threadCount,
         uint256 timeout,
         string sigHub,
-        string sigUser
+        string sigUser,
+        bool[2] checks
     ) internal view {
         require(user[0] != hub, "user can not be hub");
 
@@ -1011,11 +1016,11 @@ contract ChannelManager {
             )
         );
 
-        if (keccak256(sigHub) != keccak256("")) {
+        if (checks[0]) {
             require(hub == ECTools.recoverSigner(state, sigHub), "hub signature invalid");
         }
 
-        if (keccak256(sigUser) != keccak256("")) {
+        if (checks[1]) {
             require(user[0] == ECTools.recoverSigner(state, sigUser), "user signature invalid");
         }
     }

--- a/contracts/ChannelManager.sol
+++ b/contracts/ChannelManager.sol
@@ -1012,11 +1012,11 @@ contract ChannelManager {
         );
 
         if (keccak256(sigHub) != keccak256("")) {
-            require(hub == ECTools.recoverSigner(state, sigHub));
+            require(hub == ECTools.recoverSigner(state, sigHub), "hub signature invalid");
         }
 
         if (keccak256(sigUser) != keccak256("")) {
-            require(user[0] == ECTools.recoverSigner(state, sigUser));
+            require(user[0] == ECTools.recoverSigner(state, sigUser), "user signature invalid");
         }
     }
 

--- a/contracts/ChannelManager.sol
+++ b/contracts/ChannelManager.sol
@@ -394,7 +394,7 @@ contract ChannelManager {
 
         channel.exitInitiator = msg.sender;
         channel.channelClosingTime = now.add(challengePeriod);
-        channel.status == Status.ChannelDispute;
+        channel.status = Status.ChannelDispute;
 
         emit DidStartExitChannel(
             user[0],
@@ -487,10 +487,10 @@ contract ChannelManager {
 
         if (channel.threadCount > 0) {
             channel.threadClosingTime = now.add(challengePeriod);
-            channel.status == Status.ThreadDispute;
+            channel.status = Status.ThreadDispute;
         } else {
             channel.threadClosingTime = 0;
-            channel.status == Status.Open;
+            channel.status = Status.Open;
         }
 
         channel.exitInitiator = address(0x0);
@@ -537,10 +537,10 @@ contract ChannelManager {
 
         if (channel.threadCount > 0) {
             channel.threadClosingTime = now.add(challengePeriod);
-            channel.status == Status.ThreadDispute;
+            channel.status = Status.ThreadDispute;
         } else {
             channel.threadClosingTime = 0;
-            channel.status == Status.Open;
+            channel.status = Status.Open;
         }
 
         channel.exitInitiator = address(0x0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8166,11 +8166,16 @@
           "resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+            }
           }
         }
       }
@@ -8334,14 +8339,6 @@
             }
           }
         }
-      }
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
       }
     },
     "typical": {
@@ -8891,8 +8888,27 @@
       "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "web3-core-helpers": "1.0.0-beta.34"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          }
+        }
       }
     },
     "web3-shh": {
@@ -8937,26 +8953,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
       "integrity": "sha1-O/glj30xjHRDw28uFpQCoaZwNQY=",
       "optional": true
-    },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-      "requires": {
-        "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
-        "yaeti": "^0.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
     },
     "websocket-driver": {
       "version": "0.7.0",
@@ -9086,11 +9082,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8342,14 +8342,6 @@
         }
       }
     },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
@@ -8897,7 +8889,8 @@
       "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.34",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       },
       "dependencies": {
         "debug": {
@@ -8910,10 +8903,27 @@
         },
         "websocket": {
           "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
           "requires": {
             "debug": "^2.2.0",
-            "nan": "^2.3.3"
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          },
+          "dependencies": {
+            "typedarray-to-buffer": {
+              "version": "3.1.5",
+              "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+              "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+              "requires": {
+                "is-typedarray": "^1.0.0"
+              }
+            },
+            "yaeti": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+              "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+            }
           }
         }
       }
@@ -8960,26 +8970,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
       "integrity": "sha1-O/glj30xjHRDw28uFpQCoaZwNQY=",
       "optional": true
-    },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-      "requires": {
-        "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
-        "yaeti": "^0.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
     },
     "websocket-driver": {
       "version": "0.7.0",
@@ -9109,11 +9099,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8904,9 +8904,7 @@
           "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
           "requires": {
             "debug": "^2.2.0",
-            "nan": "^2.3.3",
-            "typedarray-to-buffer": "^3.1.2",
-            "yaeti": "^0.0.6"
+            "nan": "^2.3.3"
           }
         }
       }

--- a/test/channelManager.js
+++ b/test/channelManager.js
@@ -50,7 +50,7 @@ function getEventParams(tx, event) {
   return false
 }
 
-async function initHash(contract, init) {
+async function initHash(contract, init, accountIndex) {
   const hash = await web3.utils.soliditySha3(
     contract.address,
     {type: 'address[2]', value: [init.user, init.recipient]},
@@ -63,7 +63,7 @@ async function initHash(contract, init) {
     init.threadCount,
     init.timeout
   )
-  const sig = await web3.eth.accounts.sign(hash, privKeys[0])
+  const sig = await web3.eth.accounts.sign(hash, privKeys[accountIndex])
   return sig.signature
 }
 
@@ -132,7 +132,7 @@ contract("ChannelManager::hubAuthorizedUpdate", accounts => {
     })
 
     it("happy case", async() => {
-      init.sigUser = await initHash(channelManager, init)
+      init.sigUser = await initHash(channelManager, init, 1)
       await channelManager.hubAuthorizedUpdate(
         init.user,
         init.recipient,
@@ -176,7 +176,7 @@ contract("ChannelManager::userAuthorizedUpdate", accounts => {
     })
 
     it("happy case", async() => {
-      init.sigUser = await initHash(channelManager, init)
+      init.sigHub = await initHash(channelManager, init, 0)
       await channelManager.userAuthorizedUpdate(
         init.recipient,
         init.weiBalances,
@@ -187,7 +187,8 @@ contract("ChannelManager::userAuthorizedUpdate", accounts => {
         init.threadRoot,
         init.threadCount,
         init.timeout,
-        init.sigUser
+        init.sigHub,
+        { from: accounts[1] }
       )
     })
   })
@@ -245,7 +246,7 @@ contract("ChannelManager::startExitWithUpdate", accounts => {
         init.timeout
       )
       const signatureHub = await web3.eth.accounts.sign(hash, privKeys[0])
-      const signatureUser = await web3.eth.accounts.sign(hash, privKeys[0])
+      const signatureUser = await web3.eth.accounts.sign(hash, privKeys[1])
 
       init.sigHub = signatureHub.signature
       init.sigUser = signatureUser.signature


### PR DESCRIPTION
Update to fix: 

> if you send sigUser in hubAuthorizedUpdate or sigHub in userAuthorizedUpdate as empty strings it will always pass _verifySig method as it doesn't check signature if string is empty(edited)

as described by the decenter audit