### PR TITLE
Revert "5. Redundant noReentrency modifiers increase gas usage"

### DIFF
--- a/contracts/ChannelManager.sol
+++ b/contracts/ChannelManager.sol
@@ -313,7 +313,7 @@ contract ChannelManager {
     // start exit with onchain state
     function startExit(
         address user
-    ) public {
+    ) public noReentrancy {
         Channel storage channel = channels[user];
         require(channel.status == Status.Open, "channel must be open");
 
@@ -347,7 +347,7 @@ contract ChannelManager {
         uint256 timeout,
         string sigHub,
         string sigUser
-    ) public {
+    ) public noReentrancy {
         Channel storage channel = channels[user[0]];
         require(channel.status == Status.Open, "channel must be open");
 
@@ -567,7 +567,7 @@ contract ChannelManager {
         uint256 txCount,
         bytes proof,
         string sig
-    ) public {
+    ) public noReentrancy {
         Channel storage channel = channels[user];
         require(channel.status == Status.ThreadDispute, "channel must be in thread dispute phase");
         require(now < channel.threadClosingTime, "channel thread closing time must not have passed");
@@ -608,7 +608,7 @@ contract ChannelManager {
         uint256[2] updatedTokenBalances, // [sender, receiver]
         uint256 updatedTxCount,
         string updateSig
-    ) public {
+    ) public noReentrancy {
         Channel storage channel = channels[user];
         require(channel.status == Status.ThreadDispute, "channel must be in thread dispute phase");
         require(now < channel.threadClosingTime, "channel thread closing time must not have passed");


### PR DESCRIPTION
This reverts commit df470d9e0514ab4361b05d00cbc35dbf1964426d.

Assuming the token cannot be trusted (otherwise we could just remove
*all* reentrancy guards), this is dangerous advice, because a malicious
token could still wreak havoc by calling a contract function (g)
different from the one it was called *from* (f).
g would then operate on possibly inconsistent or "unfinished" (by f)
state.
Hence, the entire contract must be protected against reentrancies,
not just the functions that call untrusted code (which, I guess, was
the idea; I haven't seen the report).