### PR TITLE
Thread Disputes Review (thread timers change)

### DIFF
--- a/contracts/ChannelManager.sol
+++ b/contracts/ChannelManager.sol
@@ -605,8 +605,8 @@ contract ChannelManager {
 
         require(thread.status == ThreadStatus.Settled, "thread must be settled");
 
-        // verify initial thread state
-        _verifyThread(sender, receiver, threadId, weiBalances, tokenBalances, 0, proof, sig, channel.threadRoot);
+        // verify initial thread state. Explicitly set txCount and recipient balances to 0
+        _verifyThread(sender, receiver, threadId, [weiBalances[0], 0], [tokenBalances[0], 0], 0, proof, sig, channel.threadRoot);
 
         require(thread.weiBalances[0].add(thread.weiBalances[1]) == weiBalances[0].add(weiBalances[1]), "updated wei balances must match sum of initial wei balances");
         require(thread.tokenBalances[0].add(thread.tokenBalances[1]) == tokenBalances[0].add(tokenBalances[1]), "updated token balances must match sum of initial token balances");
@@ -684,7 +684,8 @@ contract ChannelManager {
 
         require(thread.status == ThreadStatus.Open, "thread must be open");
 
-        _verifyThread(sender, receiver, threadId, weiBalances, tokenBalances, 0, proof, sig, channel.threadRoot);
+        //explicitly set txCount and recipient balances to zero
+        _verifyThread(sender, receiver, threadId, [weiBalances[0], 0], [tokenBalances[0], 0], 0, proof, sig, channel.threadRoot);
 
         thread.weiBalances = weiBalances;
         thread.tokenBalances = tokenBalances;
@@ -725,7 +726,8 @@ contract ChannelManager {
         Thread storage thread = threads[threadMembers[0]][threadMembers[1]][threadId];
         require(thread.status == ThreadStatus.Open, "thread must be open");
 
-        _verifyThread(threadMembers[0], threadMembers[1], threadId, weiBalances, tokenBalances, 0, proof, sig, channel.threadRoot);
+        //explicitly set txCount and recipient balances to zero
+        _verifyThread(threadMembers[0], threadMembers[1], threadId, [weiBalances[0], 0], [tokenBalances[0], 0], 0, proof, sig, channel.threadRoot);
 
         // *********************
         // PROCESS THREAD UPDATE

--- a/contracts/ChannelManager.sol
+++ b/contracts/ChannelManager.sol
@@ -639,6 +639,10 @@ contract ChannelManager {
             require(approvedToken.transfer(user, thread.tokenBalances[0]), "user [sender] token withdrawal transfer failed");
         }
 
+        // zero out thread balances
+        thread.weiBalances = [0, 0];
+        thread.tokenBalances = [0, 0];
+
         // decrement the channel threadCount
         channel.threadCount = channel.threadCount.sub(1);
 


### PR DESCRIPTION
Thread dispute rework to attach timers to individual threads rather than a global timer

Contains the following:
- HST integration (latest update from master branch)
- Ameen's interactive thread challenges (latest update from threadID branch)
- Adds `threadClosingTime` and `emptied` bool to thread struct
- updates `channel.threadClosingTime` references -> `thread.threadClosingTime` as appropriate
- combines `emptyThread` and `exitSettledThread` into one function
- removes redundant thread status enum and `user` fields in `challengeThread` function + `DidChallengeThread` event
- updates `nukeThreads` to use channelClosingTime

Rationale and notes: https://www.notion.so/connext/Thread-dispute-review-notes-v2-509c41ea5974465e98be55af4edbcff7

This should be the latest branch, can safely delete threadIDs as well when this is merged.